### PR TITLE
Fix optional value processing

### DIFF
--- a/src/helper.ts
+++ b/src/helper.ts
@@ -107,6 +107,8 @@ function processDef(def: ZodTypeAny, o: any, key: string, value: string) {
     parsedValue = Boolean(value)
   } else if (def instanceof ZodOptional) {
     processDef(def.unwrap(), o, key, value)
+    // return here to prevent overwriting the result of the recursive call
+    return
   } else if (def instanceof ZodArray) {
     if (o[key] === undefined) {
       o[key] = []

--- a/test/helper.test.ts
+++ b/test/helper.test.ts
@@ -7,6 +7,7 @@ const mySchema = z.object({
   c: z.boolean(),
   d: z.string().optional(),
   e: z.number(),
+  f: z.string().optional(),
 })
 type MyParams = z.infer<typeof mySchema>
 
@@ -18,11 +19,12 @@ describe('test getParams', () => {
     params.append('b', '2')
     params.set('c', 'true')
     params.set('e', '10')
+    params.set('f', 'y')
 
     const { success, data } = getParams<MyParams>(params, mySchema)
 
     expect(success).toBe(true)
-    expect(data).toEqual({ a: 'x', b: [1, 2], c: true, e: 10 })
+    expect(data).toEqual({ a: 'x', b: [1, 2], c: true, e: 10, f: 'y' })
   })
 
   it('should return error', () => {


### PR DESCRIPTION
Added a missing return statement to prevent the recursive `processDef()` result from being overwritten (optional values would always be undefined)