### PR TITLE
Infer empty params as if they were undefined

### DIFF
--- a/src/helper.ts
+++ b/src/helper.ts
@@ -1,11 +1,10 @@
 import {
-  ZodRawShape,
-  ZodNumber,
-  ZodBoolean,
   ZodArray,
+  ZodBoolean,
+  ZodNumber,
   ZodOptional,
-  ZodTypeAny,
   ZodString,
+  ZodTypeAny,
 } from 'zod'
 
 export function getParams<T>(
@@ -19,6 +18,10 @@ export function getParams<T>(
   let o: any = {}
   // @ts-ignore
   for (let [key, value] of Array.from(params)) {
+    // infer an empty param as if it wasn't defined in the first place
+    if (value === '') {
+      continue
+    }
     const def = shape[key]
     if (def) {
       processDef(def, o, key, value as string)

--- a/test/helper.test.ts
+++ b/test/helper.test.ts
@@ -8,6 +8,7 @@ const mySchema = z.object({
   d: z.string().optional(),
   e: z.number(),
   f: z.string().optional(),
+  g: z.string().default('z'),
 })
 type MyParams = z.infer<typeof mySchema>
 
@@ -20,16 +21,17 @@ describe('test getParams', () => {
     params.set('c', 'true')
     params.set('e', '10')
     params.set('f', 'y')
+    params.set('g', '') // empty params should use the default value when provided one
 
     const { success, data } = getParams<MyParams>(params, mySchema)
 
     expect(success).toBe(true)
-    expect(data).toEqual({ a: 'x', b: [1, 2], c: true, e: 10, f: 'y' })
+    expect(data).toEqual({ a: 'x', b: [1, 2], c: true, e: 10, f: 'y', g: 'z' })
   })
 
   it('should return error', () => {
     const params = new URLSearchParams()
-    params.set('a', 'x')
+    params.set('a', '') // empty param should be inferred as if it was undefined
     params.append('b', '1')
     params.append('b', 'x') // invalid number
     //params.set('c', 'true') missing required param
@@ -37,6 +39,7 @@ describe('test getParams', () => {
 
     const { success, errors } = getParams<MyParams>(params, mySchema)
     expect(success).toBe(false)
+    expect(errors?.['a']).toEqual(`Required string for a`)
     expect(errors?.['b']).toEqual(
       `Expected number, received string 'x' for b[1]`,
     )


### PR DESCRIPTION
When calling `getParams()` with the following search params: `?someparam=`, the following things will happen:
- if `someparam` is a required value, the parsing will fail
- if `someparam` has a `.default()` value, it gets utilized instead of using the empty string that was provided