### PR TITLE
Add actual support for .default()

### DIFF
--- a/src/helper.ts
+++ b/src/helper.ts
@@ -1,6 +1,7 @@
 import {
   ZodArray,
   ZodBoolean,
+  ZodDefault,
   ZodNumber,
   ZodOptional,
   ZodString,
@@ -108,8 +109,9 @@ function processDef(def: ZodTypeAny, o: any, key: string, value: string) {
     parsedValue = isNaN(num) ? value : num
   } else if (def instanceof ZodBoolean) {
     parsedValue = Boolean(value)
-  } else if (def instanceof ZodOptional) {
-    processDef(def.unwrap(), o, key, value)
+  } else if (def instanceof ZodOptional || def instanceof ZodDefault) {
+    // def._def.innerType is the same as ZodOptional's .unwrap(), which unfortunately doesn't exist on ZodDefault
+    processDef(def._def.innerType, o, key, value)
     // return here to prevent overwriting the result of the recursive call
     return
   } else if (def instanceof ZodArray) {

--- a/test/helper.test.ts
+++ b/test/helper.test.ts
@@ -9,6 +9,7 @@ const mySchema = z.object({
   e: z.number(),
   f: z.string().optional(),
   g: z.string().default('z'),
+  h: z.string().default('z'),
 })
 type MyParams = z.infer<typeof mySchema>
 
@@ -22,11 +23,20 @@ describe('test getParams', () => {
     params.set('e', '10')
     params.set('f', 'y')
     params.set('g', '') // empty params should use the default value when provided one
+    params.set('h', 'something')
 
     const { success, data } = getParams<MyParams>(params, mySchema)
 
     expect(success).toBe(true)
-    expect(data).toEqual({ a: 'x', b: [1, 2], c: true, e: 10, f: 'y', g: 'z' })
+    expect(data).toEqual({
+      a: 'x',
+      b: [1, 2],
+      c: true,
+      e: 10,
+      f: 'y',
+      g: 'z',
+      h: 'something',
+    })
   })
 
   it('should return error', () => {


### PR DESCRIPTION
.default() would previously work fine if the param was either empty or missing, but when an actual param was provided the processing would fail due to the unhandled object type