### PR TITLE
Add getParams, getSearchParams and getFormData helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Zod is a peer dependency
 
 Zod is used to validate untyped data and either return a valid object or a list of errors encounted.
 
-To use the helper, first define your Zod schema and generate a TypeScript type using `z.infer`.
+To use the helper, first define your Zod schema:
 
 ```ts
 const ParamsSchema = z.object({
@@ -34,16 +34,15 @@ const ParamsSchema = z.object({
   d: z.string().optional(),
   e: z.array(z.number()),
 })
-type ParamsType = z.infer<typeof ParamsSchema>
 ```
 
 ## 📝 API Reference
 
-### `getParams<T>(params, schema)`
+### `getParams(params, schema)`
 
 This function is used to parse and validate data from `URLSearchParams`, `FormData`, or Remix `params` object.
 
-It returns an object that has `success` property. If `result.success` is `true` then `result.data` will be a valid object of type `T`.
+It returns an object that has `success` property. If `result.success` is `true` then `result.data` will be a valid object of type `T`, inferred from your Zod schema.
 
 Otherwise, `result.errors` will be an object with keys for each property that failed validation. The key value will be the validation error message.
 
@@ -61,7 +60,33 @@ Unlike `Object.fromEntries()`, this function also supports multi-value keys and 
 
 ```ts
 const url = new URL(request.url)
-const result = getParams<ParamsType>(url.searchParams, ParamsSchema)
+const result = getParams(url.searchParams, ParamsSchema)
+if (!result.success) {
+  throw new Response(result.errors, { status: 400 })
+}
+// these variable will be typed and valid
+const { a, b, c, d, e } = result.data
+```
+
+### `getSearchParams(request, schema)`
+
+This helper function is used to parse and validate `URLSearchParams` data from the `Request` found in the Remix action/loader, it returns the same result values as `getParams`.
+
+```ts
+const result = getSearchParams(request, ParamsSchema)
+if (!result.success) {
+  throw new Response(result.errors, { status: 400 })
+}
+// these variable will be typed and valid
+const { a, b, c, d, e } = result.data
+```
+
+### `getFormData(request, schema)`
+
+This helper function is used to parse and validate `FormData` data from the `Request` found in the Remix action/loader, it returns the same result values as `getParams`.
+
+```ts
+const result = getFormData(request, ParamsSchema)
 if (!result.success) {
   throw new Response(result.errors, { status: 400 })
 }

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ const { a, b, c, d, e } = result.data
 This helper function is used to parse and validate `FormData` data from the `Request` found in the Remix action/loader, it returns the same result values as `getParams`.
 
 ```ts
-const result = getFormData(request, ParamsSchema)
+const result = await getFormData(request, ParamsSchema)
 if (!result.success) {
   throw new Response(result.errors, { status: 400 })
 }

--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
   },
   "jest": {
     "preset": "ts-jest/presets/default-esm",
-    "testEnvironment": "node"
+    "testEnvironment": "jsdom"
   }
 }

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -167,8 +167,6 @@ function defInputType(def: ZodTypeAny) {
     type = 'number'
   } else if (def instanceof ZodBoolean) {
     type = 'checkbox'
-  } else if (def instanceof ZodNativeEnum || def instanceof ZodEnum) {
-    type = 'select'
   } else if (def instanceof ZodArray) {
     type = defInputType(def.element)
   } else if (def instanceof ZodOptional) {

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -1,4 +1,5 @@
 import {
+  z,
   ZodArray,
   ZodBoolean,
   ZodDefault,
@@ -7,10 +8,11 @@ import {
   ZodNumber,
   ZodOptional,
   ZodString,
+  ZodType,
   ZodTypeAny,
 } from 'zod'
 
-export function getParams<T>(
+function getParamsInternal<T>(
   params: URLSearchParams | FormData | any,
   schema: any,
 ):
@@ -69,6 +71,32 @@ export function getParams<T>(
     }
     return { success: false, data: undefined, errors }
   }
+}
+
+export function getParams<T extends ZodType<any, any, any>>(
+  params: URLSearchParams | FormData | any,
+  schema: T,
+) {
+  type ParamsType = z.infer<T>
+  return getParamsInternal<ParamsType>(params, schema)
+}
+
+export function getSearchParams<T extends ZodType<any, any, any>>(
+  request: Pick<Request, 'url'>,
+  schema: T,
+) {
+  type ParamsType = z.infer<T>
+  let url = new URL(request.url)
+  return getParams<ParamsType>(url.searchParams, schema)
+}
+
+export async function getFormData<T extends ZodType<any, any, any>>(
+  request: Pick<Request, 'formData'>,
+  schema: T,
+) {
+  type ParamsType = z.infer<T>
+  let data = await request.formData()
+  return getParams<ParamsType>(data, schema)
 }
 
 export type InputPropType = {
@@ -139,6 +167,8 @@ function defInputType(def: ZodTypeAny) {
     type = 'number'
   } else if (def instanceof ZodBoolean) {
     type = 'checkbox'
+  } else if (def instanceof ZodNativeEnum || def instanceof ZodEnum) {
+    type = 'select'
   } else if (def instanceof ZodArray) {
     type = defInputType(def.element)
   } else if (def instanceof ZodOptional) {

--- a/test/helper.test.ts
+++ b/test/helper.test.ts
@@ -1,5 +1,10 @@
 import { z } from 'zod'
-import { getParams, useFormInputProps } from '../src/helper'
+import {
+  getFormData,
+  getParams,
+  getSearchParams,
+  useFormInputProps,
+} from '../src/helper'
 
 enum TestEnum {
   A = 'A',
@@ -29,7 +34,6 @@ const mySchema = z.object({
     .min(5, { message: 'Email must be at least 5 characters' })
     .optional(),
 })
-type MyParams = z.infer<typeof mySchema>
 
 describe('test getParams', () => {
   it('should return data from URLSearchParams', () => {
@@ -45,10 +49,10 @@ describe('test getParams', () => {
     params.set('zodEnum', 'A')
     params.set('nativeEnum', 'B')
 
-    const { success, data, errors } = getParams<MyParams>(params, mySchema)
-    console.log(errors)
+    const { success, data, errors } = getParams(params, mySchema)
 
     expect(success).toBe(true)
+    expect(errors).toBeUndefined()
     expect(data).toEqual({
       a: 'abcdef',
       b: [1, 2],
@@ -72,8 +76,147 @@ describe('test getParams', () => {
     params.set('email', 'abc')
     params.set('zodEnum', 'C')
     params.set('nativeEnum', 'D')
-    const { success, errors } = getParams<MyParams>(params, mySchema)
+
+    const { success, errors } = getParams(params, mySchema)
+
     expect(success).toBe(false)
+    expect(errors?.['a']).toEqual(`a is required`)
+    expect(errors?.['b']).toEqual('Expected number, received string')
+    expect(errors?.['c']).toEqual(`c is required`)
+    expect(errors?.['e']).toEqual('Expected number, received string')
+    expect(errors?.['zodEnum']).toEqual(
+      "Invalid enum value. Expected 'A' | 'B', received 'C'",
+    )
+    expect(errors?.['nativeEnum']).toEqual(
+      "Invalid enum value. Expected 'A' | 'B', received 'D'",
+    )
+    expect(errors?.['email']).toEqual([
+      'Invalid email',
+      'Email must be at least 5 characters',
+    ])
+  })
+})
+
+describe('test getSearchParamsFromRequest', () => {
+  it('should return data from Request', () => {
+    const url = new URL('http://localhost')
+    url.searchParams.set('a', 'abcdef')
+    url.searchParams.append('b', '1')
+    url.searchParams.append('b', '2')
+    url.searchParams.set('c', 'true')
+    url.searchParams.set('e', '10')
+    url.searchParams.set('f', 'y')
+    url.searchParams.set('g', '') // empty url.searchParams should use the default value when provided one
+    url.searchParams.set('h', 'something')
+    url.searchParams.set('zodEnum', 'A')
+    url.searchParams.set('nativeEnum', 'B')
+
+    const { success, data, errors } = getSearchParams(
+      { url: url.toString() },
+      mySchema,
+    )
+
+    expect(success).toBe(true)
+    expect(errors).toBeUndefined()
+    expect(data).toEqual({
+      a: 'abcdef',
+      b: [1, 2],
+      c: true,
+      e: 10,
+      f: 'y',
+      g: 'z',
+      h: 'something',
+      zodEnum: 'A',
+      nativeEnum: TestEnum.B,
+    })
+  })
+
+  it('should return error', () => {
+    const url = new URL('http://localhost')
+    url.searchParams.set('a', '') // empty param should be inferred as if it was undefined
+    url.searchParams.append('b', '1')
+    url.searchParams.append('b', 'x') // invalid number
+    //url.searchParams.set('c', 'true') missing required param
+    url.searchParams.set('e', 'xyz') // invalid number
+    url.searchParams.set('email', 'abc')
+    url.searchParams.set('zodEnum', 'C')
+    url.searchParams.set('nativeEnum', 'D')
+
+    const { success, data, errors } = getSearchParams(
+      { url: url.toString() },
+      mySchema,
+    )
+    expect(success).toBe(false)
+    expect(data).toBeUndefined()
+    expect(errors?.['a']).toEqual(`a is required`)
+    expect(errors?.['b']).toEqual('Expected number, received string')
+    expect(errors?.['c']).toEqual(`c is required`)
+    expect(errors?.['e']).toEqual('Expected number, received string')
+    expect(errors?.['zodEnum']).toEqual(
+      "Invalid enum value. Expected 'A' | 'B', received 'C'",
+    )
+    expect(errors?.['nativeEnum']).toEqual(
+      "Invalid enum value. Expected 'A' | 'B', received 'D'",
+    )
+    expect(errors?.['email']).toEqual([
+      'Invalid email',
+      'Email must be at least 5 characters',
+    ])
+  })
+})
+
+describe('test getFormDataFromRequest', () => {
+  it('should return data from Request', async () => {
+    let formData = new FormData()
+    formData.set('a', 'abcdef')
+    formData.append('b', '1')
+    formData.append('b', '2')
+    formData.set('c', 'true')
+    formData.set('e', '10')
+    formData.set('f', 'y')
+    formData.set('g', '') // empty formData should use the default value when provided one
+    formData.set('h', 'something')
+    formData.set('zodEnum', 'A')
+    formData.set('nativeEnum', 'B')
+
+    const { success, data, errors } = await getFormData(
+      { formData: async () => formData },
+      mySchema,
+    )
+
+    expect(success).toBe(true)
+    expect(errors).toBeUndefined()
+    expect(data).toEqual({
+      a: 'abcdef',
+      b: [1, 2],
+      c: true,
+      e: 10,
+      f: 'y',
+      g: 'z',
+      h: 'something',
+      zodEnum: 'A',
+      nativeEnum: TestEnum.B,
+    })
+  })
+
+  it('should return error', async () => {
+    let formData = new FormData()
+    formData.set('a', '') // empty param should be inferred as if it was undefined
+    formData.append('b', '1')
+    formData.append('b', 'x') // invalid number
+    //formData.set('c', 'true') missing required param
+    formData.set('e', 'xyz') // invalid number
+    formData.set('email', 'abc')
+    formData.set('zodEnum', 'C')
+    formData.set('nativeEnum', 'D')
+
+    const { success, data, errors } = await getFormData(
+      { formData: async () => formData },
+      mySchema,
+    )
+
+    expect(success).toBe(false)
+    expect(data).toBeUndefined()
     expect(errors?.['a']).toEqual(`a is required`)
     expect(errors?.['b']).toEqual('Expected number, received string')
     expect(errors?.['c']).toEqual(`c is required`)
@@ -109,6 +252,17 @@ describe('test useFormInputProps', () => {
       type: 'number',
       name: 'e',
       required: true,
+    })
+
+    expect(inputProps('zodEnum')).toEqual({
+      type: 'select',
+      name: 'zodEnum',
+      required: true,
+    })
+
+    expect(inputProps('nativeEnum')).toEqual({
+      type: 'select',
+      name: 'nativeEnum',
     })
   })
   it('should throw with invalid key', () => {

--- a/test/helper.test.ts
+++ b/test/helper.test.ts
@@ -253,17 +253,6 @@ describe('test useFormInputProps', () => {
       name: 'e',
       required: true,
     })
-
-    expect(inputProps('zodEnum')).toEqual({
-      type: 'select',
-      name: 'zodEnum',
-      required: true,
-    })
-
-    expect(inputProps('nativeEnum')).toEqual({
-      type: 'select',
-      name: 'nativeEnum',
-    })
   })
   it('should throw with invalid key', () => {
     const inputProps = useFormInputProps(mySchema)


### PR DESCRIPTION
Simplify usage within Remix by inferring the type for each helper and extracting the correct information from a Request where appropriate.