### PR TITLE
Fix Remix's params object parsing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,13 @@
 {
   "name": "remix-params-helper",
-  "version": "0.1.4",
+  "version": "0.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "remix-params-helper",
-      "version": "0.1.4",
+      "version": "0.3.1",
       "license": "MIT",
-      "dependencies": {
-        "zod": "^3.11.6"
-      },
       "devDependencies": {
         "@babel/core": "^7.16.0",
         "@babel/preset-env": "^7.16.4",
@@ -24,6 +21,9 @@
         "ts-jest": "^27.0.7",
         "ts-node": "^10.4.0",
         "typescript": "^4.5.2"
+      },
+      "peerDependencies": {
+        "zod": "^3.11.6"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4672,15 +4672,23 @@
       "dev": true
     },
     "node_modules/node-fetch": {
-      "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
-      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
       "dev": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
       "engines": {
         "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/node-fetch/node_modules/tr46": {
@@ -6018,6 +6026,7 @@
       "version": "3.11.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.11.6.tgz",
       "integrity": "sha512-daZ80A81I3/9lIydI44motWe6n59kRBfNzTuS2bfzVh1nAXi667TOTWWtatxyG+fwgNUiagSj/CWZwRRbevJIg==",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -9066,7 +9075,8 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "27.4.0",
@@ -9523,9 +9533,9 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
-      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
       "dev": true,
       "requires": {
         "whatwg-url": "^5.0.0"
@@ -10466,7 +10476,8 @@
       "version": "7.5.6",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.6.tgz",
       "integrity": "sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "xml-name-validator": {
       "version": "3.0.0",
@@ -10522,7 +10533,8 @@
     "zod": {
       "version": "3.11.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.11.6.tgz",
-      "integrity": "sha512-daZ80A81I3/9lIydI44motWe6n59kRBfNzTuS2bfzVh1nAXi667TOTWWtatxyG+fwgNUiagSj/CWZwRRbevJIg=="
+      "integrity": "sha512-daZ80A81I3/9lIydI44motWe6n59kRBfNzTuS2bfzVh1nAXi667TOTWWtatxyG+fwgNUiagSj/CWZwRRbevJIg==",
+      "peer": true
     }
   }
 }

--- a/test/helper.test.ts
+++ b/test/helper.test.ts
@@ -36,6 +36,19 @@ const mySchema = z.object({
 })
 
 describe('test getParams', () => {
+  it('should return data from params', () => {
+    const params = { a: 'a value' }
+    const schema = z.object({ a: z.string() })
+
+    const { success, data, errors } = getParams(params, schema)
+
+    expect(success).toBe(true)
+    expect(errors).toBeUndefined()
+    expect(data).toEqual({
+      a: 'a value',
+    })
+  })
+
   it('should return data from URLSearchParams', () => {
     const params = new URLSearchParams()
     params.set('a', 'abcdef')


### PR DESCRIPTION
The README states that `getParams` can be used with Remix's `params` object. When I tried doing so, it failed to parse its contents. It seems this was due to the code in `getParamsInternal` relying on params being an iterable. Because the `params` object isn't this produced an empty array when calling `Array.from(params)` in the `for...of`.

This PR attempts to fix this. I've also included a couple of small type edits and an updated lock file. Feel free to suggest any changes that you'd like to work into the PR.