### PR TITLE
maxLength vs maxLength

### DIFF
--- a/example/app/utils/helper.ts
+++ b/example/app/utils/helper.ts
@@ -182,8 +182,8 @@ export type InputPropType = {
   required?: boolean
   min?: number
   max?: number
-  minlength?: number
-  maxlength?: number
+  minLength?: number
+  maxLength?: number
   pattern?: string
 }
 
@@ -274,8 +274,8 @@ function getInputProps(name: string, def: ZodTypeAny): InputPropType {
   if (!def.isOptional()) inputProps.required = true
   if (min) inputProps.min = min
   if (max) inputProps.max = max
-  if (minlength && Number.isFinite(minlength)) inputProps.minlength = minlength
-  if (maxlength && Number.isFinite(maxlength)) inputProps.maxlength = maxlength
+  if (minlength && Number.isFinite(minlength)) inputProps.minLength = minlength
+  if (maxlength && Number.isFinite(maxlength)) inputProps.maxLength = maxlength
   if (pattern) inputProps.pattern = pattern
   return inputProps
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "remix-params-helper",
-  "version": "0.3.1",
+  "version": "0.4.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "remix-params-helper",
-      "version": "0.3.1",
+      "version": "0.4.7",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.16.0",

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -182,8 +182,8 @@ export type InputPropType = {
   required?: boolean
   min?: number
   max?: number
-  minlength?: number
-  maxlength?: number
+  minLength?: number
+  maxLength?: number
   pattern?: string
 }
 
@@ -274,8 +274,8 @@ function getInputProps(name: string, def: ZodTypeAny): InputPropType {
   if (!def.isOptional()) inputProps.required = true
   if (min) inputProps.min = min
   if (max) inputProps.max = max
-  if (minlength && Number.isFinite(minlength)) inputProps.minlength = minlength
-  if (maxlength && Number.isFinite(maxlength)) inputProps.maxlength = maxlength
+  if (minlength && Number.isFinite(minlength)) inputProps.minLength = minlength
+  if (maxlength && Number.isFinite(maxlength)) inputProps.maxLength = maxlength
   if (pattern) inputProps.pattern = pattern
   return inputProps
 }

--- a/test/helper.test.ts
+++ b/test/helper.test.ts
@@ -271,8 +271,8 @@ describe('test useFormInputProps', () => {
       type: 'text',
       name: 'a',
       required: true,
-      minlength: 5,
-      maxlength: 10,
+      minLength: 5,
+      maxLength: 10,
     })
     expect(inputProps('b')).toEqual({
       type: 'number',
@@ -335,8 +335,8 @@ describe('test useFormInputProps', () => {
       type: 'text',
       name: 'password',
       required: true,
-      minlength: 8,
-      maxlength: 20,
+      minLength: 8,
+      maxLength: 20,
     })
   })
   it('should support regex -> pattern props', () => {


### PR DESCRIPTION
It seems react prefers camelCase on the props

<img width="722" alt="Screen Shot 2022-03-11 at 14 33 45 " src="https://user-images.githubusercontent.com/792/157974704-5b235ec2-eb59-4471-ab70-47482997408d.png">

