### PR TITLE
Add support for nested fields in useFormInputProps and add typings for path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,16 @@
 {
   "name": "remix-params-helper",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "remix-params-helper",
-      "version": "0.4.7",
+      "version": "0.4.8",
       "license": "MIT",
+      "dependencies": {
+        "type-fest": "^2.12.2"
+      },
       "devDependencies": {
         "@babel/core": "^7.16.0",
         "@babel/preset-env": "^7.16.4",
@@ -2348,6 +2351,18 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-escapes/node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -5691,12 +5706,11 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "dev": true,
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.12.2.tgz",
+      "integrity": "sha512-qt6ylCGpLjZ7AaODxbpyBZSs9fCI9SkL3Z9q2oxMBQhs/uyY+VD8jHA8ULCGmWQJlBgqvO3EJeAngOHD8zQCrQ==",
       "engines": {
-        "node": ">=10"
+        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -7748,6 +7762,14 @@
       "dev": true,
       "requires": {
         "type-fest": "^0.21.3"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.21.3",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+          "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+          "dev": true
+        }
       }
     },
     "ansi-regex": {
@@ -10284,10 +10306,9 @@
       "dev": true
     },
     "type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "dev": true
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.12.2.tgz",
+      "integrity": "sha512-qt6ylCGpLjZ7AaODxbpyBZSs9fCI9SkL3Z9q2oxMBQhs/uyY+VD8jHA8ULCGmWQJlBgqvO3EJeAngOHD8zQCrQ=="
     },
     "typedarray-to-buffer": {
       "version": "3.1.5",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,9 @@
     "ts-node": "^10.4.0",
     "typescript": "^4.5.2"
   },
+  "dependencies": {
+    "type-fest": "^2.12.2"
+  },
   "peerDependencies": {
     "zod": "^3.11.6"
   },

--- a/test/helper.test.ts
+++ b/test/helper.test.ts
@@ -351,6 +351,29 @@ describe('test useFormInputProps', () => {
       pattern: '^\\d{5}$',
     })
   })
+  it.only('should support deeply nested paths', () => {
+    const schema = z.object({
+      foo: z.object({
+        bar: z.object({
+          baz: z.array(
+            z.object({
+              bears: z.object({
+                apples: z.object({
+                  bananas: z.string(),
+                }),
+              }),
+            }),
+          ),
+        }),
+      }),
+    })
+    const inputProps = useFormInputProps(schema)
+    expect(inputProps('foo.bar.baz[].bears.apples.bananas')).toEqual({
+      type: 'text',
+      name: 'foo.bar.baz[].bears.apples.bananas',
+      required: true,
+    })
+  })
 })
 
 describe('test nested objects and arrays', () => {


### PR DESCRIPTION
This PR adds support for nested properties to `useFormInputProps` and also type-checks the string paths that are passed in. Observe:

<img width="509" alt="image" src="https://user-images.githubusercontent.com/174864/161362239-c8c265b5-098b-4ab6-8160-05789e42877c.png">

However, if any part of the path is misspelled:

<img width="709" alt="image" src="https://user-images.githubusercontent.com/174864/161362257-f9517b33-8bb5-4cc1-8130-bb0e617a7ca7.png">

Unfortunately, at least with the TypeScript setup of this project, it doesn't trigger for spread props, even though when you hover it you can see that the type resolves to `never`:

<img width="604" alt="image" src="https://user-images.githubusercontent.com/174864/161362292-91515dee-43a7-4658-99f0-5ec60bc0740e.png">

TypeScript does complain when you try to spread `never` into an object though:

<img width="723" alt="image" src="https://user-images.githubusercontent.com/174864/161362413-4b556df5-e9f0-4504-af1c-05b94e940300.png">

Maybe this is a bug in TypeScript? That you're able to spread `never` into props?

Also, I was wondering why this function is called `useFormInputProps`. It doesn't compose any hooks, and it doesn't call any React APIs, so it's not really a hook, and it would be certainly more efficient to call it outside of components and use the value inside of the component. Are there plans to turn this function into a hook in the future?