### PR TITLE
Handle ZodUnion types in processDef()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "remix-params-helper",
-  "version": "0.4.7",
+  "version": "0.4.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "remix-params-helper",
-      "version": "0.4.7",
+      "version": "0.4.10",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.16.0",


### PR DESCRIPTION
Updated the processDef() function to properly handle ZodUnion types in the Zod schema. When encountering a ZodUnion, the function now tries to parse the value with each option of the union until one succeeds. If parsing fails with all options, an error will be thrown. This ensures that ZodUnion types are correctly processed during data validation.